### PR TITLE
Update load_tree to give an error message if any structures can't be …

### DIFF
--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -778,7 +778,7 @@ class AtomsCollection(object):
         |                       0: no checks, try to load from all subfolders.
         |   tolerant_loading (bool): if set to true, proceeds to load the
         |                            structures into an AtomsCollection, even
-        |                            if some of the structures could not be 
+        |                            if some of the structures could not be
         |                            read.
 
         | Returns:
@@ -822,8 +822,8 @@ class AtomsCollection(object):
         for d in dirlist:
             try:
                 if is_ext:
-                    s = ase_io.read(os.path.join(path, d, d + '.' + load_format),
-                                    **opt_args)
+                    s = ase_io.read(os.path.join(path, d, d + '.' +
+                                    load_format), **opt_args)
                 elif is_func:
                     s = load_format(os.path.join(path, d), **opt_args)
                 structures.append(s)
@@ -836,7 +836,6 @@ class AtomsCollection(object):
             info = {}
 
         percentage_failed = round((1-len(structures)/len(dirlist))*100)
-
 
         if percentage_failed > 0:
 

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -741,7 +741,8 @@ class AtomsCollection(object):
                         protocol=2)
 
     @staticmethod
-    def load_tree(path, load_format, opt_args={}, safety_check=3):
+    def load_tree(path, load_format, opt_args={}, safety_check=3,
+                  tolerant_loading=False):
         """Load a collection's structures from a series of folders, named like
         the structures, inside a given parent folder, as created by save_tree.
         The files can be loaded from a format of choice, or a
@@ -775,6 +776,10 @@ class AtomsCollection(object):
         |                          .collection file, all subfolders. Array
         |                          data will be discarded;
         |                       0: no checks, try to load from all subfolders.
+        |   tolerant_loading (bool): if set to true, proceeds to load the
+        |                            structures into an AtomsCollection, even
+        |                            if some of the structures could not be 
+        |                            read.
 
         | Returns:
         |   coll (AtomsCollection): loaded collection
@@ -821,12 +826,23 @@ class AtomsCollection(object):
             elif is_func:
                 s = load_format(os.path.join(path, d), **opt_args)
 
-            structures.append(s)
+            if s is not None:
+                structures.append(s)
 
         if check < 2:
             info = coll['info']
         else:
             info = {}
+
+        percentage_failed = round((1-len(structures)/len(dirlist))*100)
+
+        if percentage_failed > 0:
+            print("{0}% of structures could not be loaded."
+                  .format(percentage_failed))
+            if not tolerant_loading:
+                print("Set tolerant_loading to True if you would still like to"
+                      " load the remaining structures.")
+                return
 
         loaded_coll = AtomsCollection(structures, info=info)
 

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -843,7 +843,7 @@ class AtomsCollection(object):
                 raise IOError("{0}% of structures could not be loaded.".
                               format(percentage_failed))
                 return
-            elif tolerant_loading:
+            elif not tolerant_loading:
                 raise IOError("{0}% of structures could not be loaded. Set"
                               " tolerant_loading to True if you would still"
                               " like to load the remaining structures."

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -47,6 +47,8 @@ from ase.build import niggli_reduce
 from ase.calculators.singlepoint import SinglePointCalculator
 from soprano import utils
 
+utils.customize_warnings()
+
 
 class _AllCaller(object):
 

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -824,10 +824,11 @@ class AtomsCollection(object):
                 s = ase_io.read(os.path.join(path, d, d + '.' + load_format),
                                 **opt_args)
             elif is_func:
-                s = load_format(os.path.join(path, d), **opt_args)
-
-            if s is not None:
-                structures.append(s)
+                try:
+                    s = load_format(os.path.join(path, d), **opt_args)
+                    structures.append(s)
+                except Exception as e:
+                    print(e)
 
         if check < 2:
             info = coll['info']
@@ -837,12 +838,20 @@ class AtomsCollection(object):
         percentage_failed = round((1-len(structures)/len(dirlist))*100)
 
         if percentage_failed > 0:
-            print("{0}% of structures could not be loaded."
-                  .format(percentage_failed))
-            if not tolerant_loading:
-                print("Set tolerant_loading to True if you would still like to"
-                      " load the remaining structures.")
+
+            if percentage_failed == 100:
+                raise IOError("{0}% of structures could not be loaded.".
+                              format(percentage_failed))
                 return
+            elif tolerant_loading:
+                raise IOError("{0}% of structures could not be loaded. Set"
+                              " tolerant_loading to True if you would still"
+                              " like to load the remaining structures."
+                              .format(percentage_failed))
+                return
+            else:
+                print("{0}% of structures could not be loaded."
+                      .format(percentage_failed))
 
         loaded_coll = AtomsCollection(structures, info=info)
 

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -858,6 +858,8 @@ class AtomsCollection(object):
 
                 warnings.warn("{0:.0f}% of structures could not be loaded."
                               .format(percentage_failed))
+        else:
+            print("100% of structures loaded successfully.")
 
         loaded_coll = AtomsCollection(structures, info=info)
 

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -843,11 +843,11 @@ class AtomsCollection(object):
         if percentage_failed > 0:
 
             if percentage_failed == 100:
-                raise IOError("{0}% of structures could not be loaded.".
+                raise IOError("{0:.2f}% of structures could not be loaded.".
                               format(percentage_failed))
                 return
             elif not tolerant:
-                raise IOError("{0}% of structures could not be loaded. Set"
+                raise IOError("{0:.2f}% of structures could not be loaded. Set"
                               " tolerant to True if you would still"
                               " like to load the remaining structures."
                               .format(percentage_failed))
@@ -856,7 +856,7 @@ class AtomsCollection(object):
                 percentage_success = 100-percentage_failed
                 info['percentage_loaded'] = percentage_success
 
-                warnings.warn("{0:.0f}% of structures could not be loaded."
+                warnings.warn("{0:.2f}% of structures could not be loaded."
                               .format(percentage_failed))
         else:
             print("100% of structures loaded successfully.")

--- a/soprano/collection/collection.py
+++ b/soprano/collection/collection.py
@@ -820,15 +820,15 @@ class AtomsCollection(object):
 
         structures = []
         for d in dirlist:
-            if is_ext:
-                s = ase_io.read(os.path.join(path, d, d + '.' + load_format),
-                                **opt_args)
-            elif is_func:
-                try:
+            try:
+                if is_ext:
+                    s = ase_io.read(os.path.join(path, d, d + '.' + load_format),
+                                    **opt_args)
+                elif is_func:
                     s = load_format(os.path.join(path, d), **opt_args)
-                    structures.append(s)
-                except Exception as e:
-                    print(e)
+                structures.append(s)
+            except Exception as e:
+                print(e)
 
         if check < 2:
             info = coll['info']
@@ -836,6 +836,7 @@ class AtomsCollection(object):
             info = {}
 
         percentage_failed = round((1-len(structures)/len(dirlist))*100)
+
 
         if percentage_failed > 0:
 


### PR DESCRIPTION
…loaded

Adds an extra argument tolerant_loading, which if set to True still loads the tree even if some structures fail to load.