### PR TITLE
Cli nmr fix

### DIFF
--- a/soprano/scripts/cli_utils.py
+++ b/soprano/scripts/cli_utils.py
@@ -1080,7 +1080,8 @@ def find_XHn_groups(atoms, pattern_string, tags=None, vdw_scale=1.0):
         # group_tags = np.ones((len(xinds), n), dtype=int)
         seen_tags = []
         for ix, xind in enumerate(xinds):
-            group = list(np.where(bmat[xind][hinds] == 1)[0])
+            bonded_hinds = np.where(bmat[xind][hinds] == 1)[0]
+            group = list(hinds[bonded_hinds])
             assert len(group) == n
             match = []
             if len(seen_tags) > 0:

--- a/soprano/scripts/nmr.py
+++ b/soprano/scripts/nmr.py
@@ -236,7 +236,7 @@ def nmr_extract_multi(
             logger.error(
                 f"File {fname} has no {' '.join(properties)} data to extract. Skipping."
             )
-            return
+            continue
 
         atoms = nmr_extract_atoms(
             atoms,
@@ -278,6 +278,14 @@ def nmr_extract_multi(
             essential_columns=NMR_COLUMN_ALIASES["essential"],
             logger=logger,
         )
+
+        # If length of df is 0, we skip this file
+        if len(df) == 0:
+            logger.warning(
+                f"No results found for {fname}.\n "
+                "Try removing filters/checking the file contents."
+            )
+            continue
 
         # ----- atoms object manipulation -----
         # only keep the atoms that are in the dataframe (based on tag)

--- a/soprano/utils.py
+++ b/soprano/utils.py
@@ -75,12 +75,12 @@ DEFAULT_MERGING_STRATEGIES = {
     "ms_diagonal_evals_hsort": merge_first,  ## since they might be in different order ?
     "ms_diagonal_evecs": merge_first,  ## since they might be in different order ?
     "efg": merge_mean,
-    "isc": merge_mean,
-    "isc_spin": merge_mean,
-    "isc_fc": merge_mean,
-    "isc_orbital_p": merge_mean,
-    "isc_orbital_d": merge_mean,
-    "isc_orbital_f": merge_mean,
+    "isc": merge_first,
+    "isc_spin": merge_first,
+    "isc_fc": merge_first,
+    "isc_orbital_p": merge_first,
+    "isc_orbital_d": merge_first,
+    "isc_orbital_f": merge_first,
     "labels": merge_concatenate,
     "positions": merge_mean,
     "magmoms": merge_mean,


### PR DESCRIPTION
### Bug Fixes:

* In `soprano/scripts/cli_utils.py`, fixed an issue in the `find_XHn_groups` function where the wrong indices were being used for bonded hydrogen atoms. The updated code now correctly maps the bonded indices using `hinds` to ensure accurate group formation.

### Error Handling Improvements:

* In `soprano/scripts/nmr.py`, modified the `nmr_extract_multi` function to replace `return` with `continue` when skipping files without required data. This ensures the loop continues processing remaining files instead of exiting prematurely.
* Added a new check in `nmr_extract_multi` to skip files with empty dataframes. A warning is logged to inform the user about the issue and suggest possible resolutions.

### Data Merging Behavior:

* In `soprano/utils.py`, updated the `merge_sum` function to change the merging strategy for several `isc`-related keys from `merge_mean` to `merge_first`. More thought is probably needed for how to combine ISC from different sites when averaging over e.g. CH3 sites