### PR TITLE
Update simpson-conventions.md

### DIFF
--- a/docs/simpson-conventions.md
+++ b/docs/simpson-conventions.md
@@ -1,8 +1,8 @@
 # SIMPSON Tensor Conventions
 
-This page documents the conventions used by [SIMPSON](https://inano.au.dk/about/research-centers-and-projects/spinengineering/simpson) for representing NMR interaction tensors in `.spinsys` files, and how Soprano maps its internal tensors to them.
+This page documents the conventions used by [SIMPSON](https://inano.au.dk/about/research-centers-and-projects/nmr/software/simpson) for representing NMR interaction tensors in `.spinsys` files, and how Soprano maps its internal tensors to them.
 
-The conventions described below have been verified for **SIMPSON v6.0.2** through source-code inspection and numerical validation.  Internal implementation details may change in future SIMPSON releases; users should revalidate version-specific behaviour where noted.
+The conventions described below have been verified for **[SIMPSON v6.0.2](https://gitlab.au.dk/nmr/simpson)** through source-code inspection and numerical validation.  Internal implementation details may change in future SIMPSON releases; users should revalidate version-specific behaviour where noted.
 
 ## Tensor and Sign Conventions
 
@@ -33,11 +33,9 @@ SIMPSON uses **right-handed passive ZYZ Euler angles** (in degrees) to specify t
 | Isotropic J-coupling | `jcoupling` | $J_\text{iso}$ (Hz) | `iso` (Hz) | $J_\text{iso}$ (Hz) |
 | Anisotropic J-coupling | `jcoupling` | Reduced anisotropy $\zeta$ (Hz) | `aniso` (Hz) | **$\zeta/2$** (Hz, SIMPSON v6.0.2) |
 
-**Key points:**
+**Note:** 
 
-* SIMPSON internally converts all frequencies to **angular frequencies** (rad s$^{-1}$) by multiplication with $2\pi$, **except** for the dipolar coupling constant $d$, which is stored in Hz and scaled via an internal prefactor in the spatial tensor assembly (see {ref}`dipolar-section`).
-* For CSA, the `aniso` parameter is the **reduced anisotropy** $\zeta$ (the principal value $V_{zz}$ of the traceless tensor), *not* the full anisotropy $\Delta = 3\zeta/2$.
-* For J-coupling anisotropy, the `aniso` parameter must be **half the reduced anisotropy** ($\zeta/2$).  This is an implementation-specific scaling of how SIMPSON assembles the bilinear Hamiltonian (see {ref}`jcoupling-aniso-section`).
+For J-coupling anisotropy, the `aniso` parameter must be **half the reduced anisotropy** ($\zeta/2$).  This seems to be an implementation-specific scaling of how SIMPSON assembles the bilinear Hamiltonian (see {ref}`jcoupling-aniso-section`).
 
 ---
 
@@ -87,30 +85,140 @@ $$
 
 ### Magnetic shielding vs. chemical shift
 
-Soprano stores tensors internally as **magnetic shielding** ($\sigma$), where more positive values correspond to stronger shielding (more diamagnetic).  SIMPSON expects **chemical shifts** ($\delta$), defined as:
+Soprano stores NMR tensors as **magnetic shielding tensors** ($\sigma$), where larger values correspond to greater electronic shielding. In contrast, programs such as SIMPSON use **chemical shifts** ($\delta$).
+
+The chemical shift is defined as the fractional difference between the resonance frequency of a nucleus and that of a reference compound:
 
 $$
-\delta \approx \sigma_\text{ref} - \sigma
+\delta = \frac{\nu - \nu_{\mathrm{ref}}}{\nu_{\mathrm{ref}}}
 $$
 
-Soprano performs this sign change automatically when exporting to SIMPSON format, so a shielding tensor with principal values $\sigma_{zz} < \sigma_{xx} < \sigma_{yy}$ becomes a chemical shift tensor with $\delta_{zz} > \delta_{xx} > \delta_{yy}$ (assuming $\sigma_\text{ref}=0$).
+Here, $\nu_{\mathrm{ref}}$ is the resonance frequency of the chosen reference.
+
+Because the resonance frequency depends on the shielding according to
+
+$$
+\nu = \nu_0 (1 - \sigma),
+$$
+
+where $\nu_0$ is the bare Larmor frequency of the nucleus, the chemical shift can be written as
+
+$$
+\delta = \frac{\sigma_{\mathrm{ref}} - \sigma}{1 - \sigma_{\mathrm{ref}}}.
+$$
+
+Since $\sigma_{\mathrm{ref}}$ is typically only tens to hundreds of ppm ($10^{-4}$–$10^{-3}$), the denominator differs from 1 by less than 0.1%. In practice, the usual approximation is therefore
+
+$$
+\delta \approx \sigma_{\mathrm{ref}} - \sigma.
+$$
+
+This means that chemical shift is inversely related to shielding:
+
+* Larger shielding ($\sigma$) corresponds to smaller chemical shift ($\delta$) (more upfield).
+* Smaller shielding ($\sigma$) corresponds to larger chemical shift ($\delta$) (more downfield).
+
+If the shielding principal values are ordered as
+
+$$
+\sigma_{11} \le \sigma_{22} \le \sigma_{33},
+$$
+
+then the corresponding chemical shift values are ordered as
+
+$$
+\delta_{11} \ge \delta_{22} \ge \delta_{33}.
+$$
+
+The tensor axes are unchanged; only the numerical ordering is reversed.
+
+---
 
 #### `references` and `gradients` arguments
 
-In practice, DFT-computed shieldings are linearly related to experimental shifts via a calibration:
+##### `references`
+
+The `references` argument specifies the constant term in the conversion from magnetic shielding to chemical shift.
+
+Its interpretation depends on whether `gradients` is supplied:
+
+* **Direct referencing** (`gradients` omitted):
+  `reference` is the shielding of the reference compound, $\sigma_{\mathrm{ref}}$, and the expression is:
+
+   $$
+   \delta = \frac{\sigma_{\mathrm{ref}} - \sigma}{1 - \sigma_{\mathrm{ref}}}.
+   $$
+
+
+* **DFT calibration** (`gradients` explicitly supplied):
+  `reference` is the intercept $a$ of a linear regression of **experimental chemical shifts** ($\delta_{\mathrm{exp}}$, y-axis) against **computed shieldings** ($\sigma_{\mathrm{calc}}$, x-axis):
+
+  $$
+  \delta_{\mathrm{exp}} = a + m\,\sigma_{\mathrm{calc}}.
+  $$
+
+  In this form:
+
+  * `reference = a`
+  * `gradient = m`
+
+  The intercept $a$ is the predicted chemical shift for a nucleus with zero calculated shielding.
+
+  If your regression was performed in the opposite direction (i.e. with experimental shifts on the x-axis),
+
+  $$
+  \sigma_{\mathrm{calc}} = m'\,\delta_{\mathrm{exp}} + a',
+  $$
+
+  then the equivalent Soprano parameters are
+
+  $$
+  \text{gradient} = \frac{1}{m'}, \qquad \text{reference} = -\frac{a'}{m'}.
+  $$
+
+Typical values are provided per element, for example:
+
+```python
+references = {"C": 170.0, "H": 30.0}
+```
+
+If `references` is not provided, the `MagneticShielding` object contains only raw shielding values. Any attempt to export chemical shifts (for example, with `to_simpson()`) will raise a `ValueError`.
+
+---
+
+##### `gradients`
+
+The `gradients` argument specifies the slope $m$ in the conversion
 
 $$
-\delta = \frac{\sigma_\text{ref} + m\,\sigma}{1 - \sigma_\text{ref} \times 10^{-6}}
+\delta = \text{reference} + m\,\sigma.
 $$
 
-where:
+Its default value is $-1$, corresponding to the ideal relationship between shielding and chemical shift. Note the above discussion on the convention of the calibration plot assumed by Soprano. 
 
-* **`references`** ($\sigma_\text{ref}$, ppm) — the **computed** magnetic shielding of a reference compound (e.g. TMS for $^{13}$C, not an experimental ppm value).  When `references` is not supplied, it defaults to 0 and the exported shift is simply $\delta = -\sigma$.
-* **`gradients`** ($m$, dimensionless, default $-1$) — slope of the linear fit between computed shieldings and experimental shifts from a calibration set.  The ideal theoretical value is $-1$; deviations arise from systematic DFT errors and basis-set incompleteness.  A per-element gradient can be supplied to correct for these errors.
+When calibrating against experiment, the fitted slope may deviate slightly from $-1$ because of systematic errors in the computational method. Providing per-element gradients allows these deviations to be corrected.
 
-The denominator $(1 - \sigma_\text{ref} \times 10^{-6})$ is a negligible correction (of order $10^{-4}$ for typical $\sigma_\text{ref} \sim 100$ ppm) and is essentially 1 for all practical purposes.
+---
 
-Both `references` and `gradients` accept a single numerical value (applied to all sites), a per-element dictionary (e.g. `{"C": 170.0, "H": 30.0}`), or a per-site list.
+Both `references` and `gradients` can be provided as:
+
+* A single numeric value
+* A dictionary keyed by element
+* A list of per-site values
+
+Examples:
+
+```python
+references = 170.0
+references = {"C": 170.0, "H": 30.0}
+```
+
+If a single value is supplied for a system containing multiple nuclear species, Soprano issues a `UserWarning`, since different nuclei generally require different reference shieldings. For example:
+
+* $^{13}\mathrm{C}$: approximately 170 ppm
+* $^{1}\mathrm{H}$: approximately 30 ppm
+
+Applying one value to all species is usually incorrect.
 
 ---
 
@@ -133,8 +241,8 @@ $$
 \nu_\pm = \pm\frac{3C_q}{8}\bigl(3\cos^2\beta - 1\bigr)
 $$
 
-At $\beta = 0^\circ$: splitting = $3C_q/4$ (two peaks at $\pm 3C_q/8$).
-At $\beta = 90^\circ$: splitting = $3C_q/8$ (two peaks at $\pm 3C_q/8$).
+At $\beta = 0^\circ$: splitting = $3C_q/2$ (two peaks at $\pm 3C_q/4$).
+At $\beta = 90^\circ$: splitting = $3C_q/4$ (two peaks at $\pm 3C_q/8$).
 
 ---
 
@@ -155,18 +263,6 @@ Here $d$ denotes the conventional secular dipolar coupling constant in frequency
 $$
 d = -\frac{\mu_0}{4\pi}\frac{\gamma_1\gamma_2\hbar}{2\pi r^3}.
 $$
-
-### Why no $2\pi$ for dipole?
-
-Looking at SIMPSON's source (`readsys.cpp`):
-
-```cpp
-s->DD[(s->nDD)] = new Dipole(n1,n2,asym_param,orientation);
-s->DD[(s->nDD)]->delta(dipole_aniso);   // stored in Hz, NOT multiplied by 2π
-s->DD[(s->nDD)]->Rmol_c(4.0*M_PI);      // 4π prefactor
-```
-
-The Hamiltonian is assembled as `HQ_multod` with `T = IzIz_sqrt2by3` (heteronuclear) or `T20` (homonuclear).  Combined with `Dtensor2`'s $\sqrt{3/2}$ scaling, the net result is that the input $d$ Hz reproduces the conventional secular dipolar splitting $d|3\cos^2\beta - 1|$.
 
 **Do not apply any extra $2\pi$ factor to the dipolar coupling constant when exporting to SIMPSON.**
 
@@ -221,7 +317,14 @@ The anisotropic J-coupling implementation is less transparently documented than 
 Combining these factors:
 
 $$
-\text{physical coefficient} = \underbrace{\sqrt{\frac{2}{3}}}_{\text{spin op.}} \times \underbrace{\sqrt{\frac{3}{2}}}_{\text{Dtensor2}} \times \underbrace{2.0}_{\text{Rmol\_c}} \times J_\text{aniso} = 2 \, J_\text{aniso}
+\begin{aligned}
+\text{physical coefficient}
+  &= \underbrace{\sqrt{\tfrac{2}{3}}}_{\text{spin op.}}
+   \times \underbrace{\sqrt{\tfrac{3}{2}}}_{\text{Dtensor2}}
+   \times \underbrace{2}_{\text{Rmol}_{c}}
+   \times J_\text{aniso} \\
+  &= 2 \, J_\text{aniso}
+\end{aligned}
 $$
 
 The secular heteronuclear Hamiltonian at angle $\beta$ is therefore:
@@ -235,7 +338,14 @@ For the two transitions of the observed spin, the splitting is $2 J_\text{aniso}
 #### Net scaling (homonuclear)
 
 $$
-\text{physical coefficient} = \underbrace{\sqrt{\frac{1}{6}}}_{\text{spin op.}} \times \underbrace{\sqrt{\frac{3}{2}}}_{\text{Dtensor2}} \times \underbrace{2.0}_{\text{Rmol\_c}} \times J_\text{aniso} = J_\text{aniso}
+\begin{aligned}
+\text{physical coefficient}
+  &= \underbrace{\sqrt{\tfrac{1}{6}}}_{\text{spin op.}}
+   \times \underbrace{\sqrt{\tfrac{3}{2}}}_{\text{Dtensor2}}
+   \times \underbrace{2}_{\text{Rmol}_{c}}
+   \times J_\text{aniso} \\
+  &= J_\text{aniso}
+\end{aligned}
 $$
 
 The secular homonuclear Hamiltonian is:
@@ -295,11 +405,28 @@ python verify.py              # check peak positions
 
 ## References
 
-* M. Bak, J. T. Rasmussen, N. C. Nielsen, *J. Magn. Reson.* **2000**, *147*, 296–330. (SIMPSON original paper)
-* D. L. Goodwin, J. P. Carvalho, A. B. Nielsen, N. Wili, T. Vosegaard, Z. Tosner, and N. C. Nielsen, arXiv:2602.15793 (2026). (SIMPSON next-generation paper)
-* SIMPSON source code (v6.0.2), particularly `src/readsys.cpp`, `src/wigner.cpp`, `src/spinsys.cpp`, `src/ham.cpp`, and `include/sim.h`.
+* M. Bak, J. T. Rasmussen, N. C. Nielsen, [*J. Magn. Reson.* **2000**, *147*, 296–330](https://doi.org/10.1006/jmre.2000.2179). (SIMPSON original paper)
+* D. L. Goodwin, J. P. Carvalho, A. B. Nielsen, N. Wili, T. Vosegaard, Z. Tosner, and N. C. Nielsen, [arXiv:2602.15793](https://doi.org/10.48550/arXiv.2602.15793) (2026). (SIMPSON next-generation paper)
+* SIMPSON source code (v6.0.2), particularly [`src/readsys.cpp`](https://gitlab.au.dk/nmr/simpson/-/blob/main/src/readsys.cpp?ref_type=heads), [`src/wigner.cpp`](https://gitlab.au.dk/nmr/simpson/-/blob/main/src/wigner.cpp?ref_type=heads), [`src/spinsys.cpp`](https://gitlab.au.dk/nmr/simpson/-/blob/main/src/spinsys.cpp?ref_type=heads), [`src/ham.cpp`](https://gitlab.au.dk/nmr/simpson/-/blob/main/src/ham.cpp?ref_type=heads), and [`include/sim.h`](https://gitlab.au.dk/nmr/simpson/-/blob/main/include/sim.h?ref_type=heads).
 
 ---
 
-**Implementation Note:**
+## Implementation Notes
+
+SIMPSON internally converts all input frequencies (Hz) to angular frequencies (rad s⁻¹) by multiplying by $2\pi$ before assembling the Hamiltonian.  The dipolar coupling constant is a notable exception — see below.
+
+### Why no $2\pi$ for dipole?
+
+Looking at SIMPSON's source (`readsys.cpp`):
+
+```cpp
+s->DD[(s->nDD)] = new Dipole(n1,n2,asym_param,orientation);
+s->DD[(s->nDD)]->delta(dipole_aniso);   // stored in Hz, NOT multiplied by 2π
+s->DD[(s->nDD)]->Rmol_c(4.0*M_PI);      // 4π prefactor
+```
+
+The Hamiltonian is assembled as `HQ_multod` with `T = IzIz_sqrt2by3` (heteronuclear) or `T20` (homonuclear).  Combined with `Dtensor2`'s $\sqrt{3/2}$ scaling, the net result is that the input $d$ Hz reproduces the conventional secular dipolar splitting $d|3\cos^2\beta - 1|$.
+
+### Version-specific behaviour
+
 Several conventions described here—particularly the treatment of dipolar and anisotropic J-coupling scaling—are inferred from SIMPSON v6.0.2 source code and validated numerically.  These behaviours reflect the implementation of that version and may change in future releases.

--- a/docs/simpson-conventions.md
+++ b/docs/simpson-conventions.md
@@ -9,18 +9,18 @@ The conventions described below have been verified for **SIMPSON v6.0.2** throug
 Unless otherwise stated, anisotropy parameters are expressed using the **Haeberlen convention**, with reduced anisotropy
 
 $$
-\zeta = \delta_{zz} - \delta_{\mathrm{iso}}
+\zeta = \delta_{ZZ} - \delta_{\mathrm{iso}}
 $$
 
 and asymmetry parameter
 
 $$
-\eta = \frac{\delta_{yy}-\delta_{xx}}{\zeta},
+\eta = \frac{\delta_{YY}-\delta_{XX}}{\zeta},
 $$
 
-where $|\delta_{zz}-\delta_{\mathrm{iso}}| \ge |\delta_{xx}-\delta_{\mathrm{iso}}| \ge |\delta_{yy}-\delta_{\mathrm{iso}}|$.
+where $|\delta_{ZZ}-\delta_{\mathrm{iso}}| \ge |\delta_{XX}-\delta_{\mathrm{iso}}| \ge |\delta_{YY}-\delta_{\mathrm{iso}}|$.
 
-SIMPSON uses **right-handed passive ZYZ Euler angles** (in degrees) to specify the orientation of the interaction principal-axis system relative to the molecular/crystal frame.
+SIMPSON uses **right-handed passive ZYZ Euler angles** (in degrees) to specify the orientation of the interaction principal-axis system ($X$, $Y$, $Z$) relative to the molecular/crystal frame.
 
 ## Overview
 
@@ -72,11 +72,11 @@ $$
 \nu_C = \frac{\gamma_C}{\gamma_H} \times 400\,\text{MHz} \approx 100.60\,\text{MHz}
 $$
 
-So 100 ppm for $^{13}$C = $100 \times 10^{-6} \times 100.60\,\text{MHz} \approx$ **10,060 Hz** (not 40,000 Hz).
+So 100 ppm for $^{13}$C = $100 \times 10^{-6} \times 100.60\,\text{MHz} \approx$ **10,060 Hz**.
 
 ### CSA anisotropy
 
-The `aniso` parameter corresponds to the **reduced anisotropy** ($\zeta$), i.e. the $V_{zz}$ component of the traceless shielding tensor in Haeberlen convention.  It is **not** the full span-like anisotropy $\Delta = 3\zeta/2$.
+The `aniso` parameter corresponds to the **reduced anisotropy** ($\zeta$).  It is **not** the full span-like anisotropy $\Delta = 3\zeta/2$.
 
 The frequency shift for a single crystal is:
 
@@ -84,7 +84,6 @@ $$
 \delta(\beta,\gamma) = \delta_\text{iso} + \frac{\zeta}{2}\bigl(3\cos^2\beta - 1 - \eta\sin^2\beta\cos 2\gamma\bigr)
 $$
 
-Note the factor of $1/2$ in front of $\zeta$ — this is consistent with SIMPSON using the reduced anisotropy, not the full anisotropy $\Delta = 3\zeta/2$.
 
 ### Magnetic shielding vs. chemical shift
 
@@ -111,7 +110,7 @@ where:
 
 The denominator $(1 - \sigma_\text{ref} \times 10^{-6})$ is a negligible correction (of order $10^{-4}$ for typical $\sigma_\text{ref} \sim 100$ ppm) and is essentially 1 for all practical purposes.
 
-Both `references` and `gradients` accept a single float (applied to all sites), a per-element dictionary (e.g. `{"C": 170.0, "H": 30.0}`), or a per-site list.
+Both `references` and `gradients` accept a single numerical value (applied to all sites), a per-element dictionary (e.g. `{"C": 170.0, "H": 30.0}`), or a per-site list.
 
 ---
 
@@ -135,7 +134,7 @@ $$
 $$
 
 At $\beta = 0^\circ$: splitting = $3C_q/4$ (two peaks at $\pm 3C_q/8$).
-At $\beta = 90^\circ$: splitting = $-3C_q/8$ (two peaks at $\mp 3C_q/8$).
+At $\beta = 90^\circ$: splitting = $3C_q/8$ (two peaks at $\pm 3C_q/8$).
 
 ---
 

--- a/tests/simpson_validation/expected_results.md
+++ b/tests/simpson_validation/expected_results.md
@@ -20,7 +20,7 @@ SIMPSON converts chemical shift ppm to Hz using the **observed nucleus's Larmor 
 ν_C = (γ_C / γ_H) × 400 MHz ≈ 100.60 MHz
 ```
 
-Therefore, 100 ppm for ¹³C = 100 × 10⁻⁶ × 100.60 MHz ≈ **10,060 Hz** (not 40,000 Hz).
+Therefore, 100 ppm for ¹³C = 100 × 10⁻⁶ × 100.60 MHz ≈ **10,060 Hz**.
 
 ---
 
@@ -183,7 +183,7 @@ Splitting = |2d| ≈ 60.4 kHz
 ```
 dipole 1 2 -30210.667268 90.000000 0.000000 0.000000
 ```
-✓ Correct (d in Hz, no erroneous 2π factor).
+✓ Correct (d in Hz).
 
 ### 05b — β = 90° (tensor z-axis ⊥ B₀)
 ```

--- a/tests/simpson_validation/generate_tests.py
+++ b/tests/simpson_validation/generate_tests.py
@@ -60,7 +60,7 @@ def write_in_file(path, spinsys_file, par_extra, pulseq, main):
         f.write("\n".join(lines))
 
 
-def make_shift_tensor(pas_evals, beta_deg=0, gamma_deg=0):
+def make_shielding_tensor(pas_evals, beta_deg=0, gamma_deg=0):
     """Create a shielding tensor in the lab frame from PAS eigenvalues + Euler angles.
 
     pas_evals: shielding eigenvalues [sigma_xx, sigma_yy, sigma_zz] in Haeberlen PAS
@@ -117,7 +117,7 @@ def make_j_tensor(J_iso, zeta, eta=0.0, beta_deg=0, gamma_deg=0):
 # =============================================================================
 def generate_test_01():
     """Single 13C with isotropic shift +100 ppm."""
-    ms = make_shift_tensor([-100, -100, -100], beta_deg=0)  # shielding = -shift
+    ms = make_shielding_tensor([-100, -100, -100], beta_deg=0)  # shielding = -shift
     site = Site(isotope="13C", label="C1", index=0, ms=ms)
     spin = SpinSystem(sites=[site])
 
@@ -149,7 +149,7 @@ def generate_test_02():
     # Shielding PAS eigenvalues: sigma = -delta  =>  [100, 100, -200]
     pas = [100, 100, -200]
     for suffix, beta in [("a", 0), ("b", 90), ("c", 54.73561032)]:
-        ms = make_shift_tensor(pas, beta_deg=beta)
+        ms = make_shielding_tensor(pas, beta_deg=beta)
         site = Site(isotope="13C", label="C1", index=0, ms=ms)
         spin = SpinSystem(sites=[site])
 
@@ -182,7 +182,7 @@ def generate_test_03():
     # Shielding PAS: sigma_xx=225, sigma_yy=75, sigma_zz=-300
     pas = [225, 75, -300]
     for suffix, gamma in [("a", 0), ("b", 90)]:
-        ms = make_shift_tensor(pas, beta_deg=90, gamma_deg=gamma)
+        ms = make_shielding_tensor(pas, beta_deg=90, gamma_deg=gamma)
         site = Site(isotope="13C", label="C1", index=0, ms=ms)
         spin = SpinSystem(sites=[site])
 


### PR DESCRIPTION
Some quick tweaks.

Other points:

The SIMPSON link in the 1st line is now broken.


**"SIMPSON internally converts all frequencies to angular frequencies (rad s
-1) ..."**
The references to internal behaviour are a bit confusing to a user. I would separate out "user tutorial" from "Implementation notes" which could go at the end,

**For CSA, the aniso parameter is the reduced anisotropy  (the principal value  of the traceless tensor), not the full anisotropy** 

This is stated in two places.


**For J-coupling anisotropy, the aniso parameter must be half the reduced anisotropy.** 

I suspect this is a misfeature related to the fact that nobody cares about / tests the reduced J-coupling anisotropy. You are right to warn that this behaviour may be unstable.


**Note the factor of 1/2 in front of  — this is consistent with SIMPSON using the reduced anisotropy, not the full anisotropy .**

Not really, this is more to do with (3 cos^2 \theta -1)/2

**Magnetic shielding vs. chemical shift**

I would first define \sigma = (\nu - \nu_ref) / \nu_ref.
Where \nu_ref is the frequency of a reference compound with zero shift. This is the definition of chemical shift. It is complicated by some nuclei where the reference compound shift is not zero.

This should equate to (\sigma_ref - \sigma)/(1 - \sigma_ref) where \sigma_ref is the shielding again of reference with zero shift.

**Soprano performs this sign change automatically when exporting to SIMPSON format**

This is ambiguous. You can't "perform a sign change" based on a formula with approx in it.


** When references is not supplied, it defaults to 0 **

I'm not sure this make sense. I would insist on reference.

** gradients — slope of the linear fit between computed shieldings and experimental shifts from a calibration set. **

I think, especially with the 1 - sigma issue, we have to be clear whether plot is shielding vs shift or shift vs shielding. shift on the horizontal axis ensures that the y-intercept is the sigma corresponding to 0 ppm shift, which should then be sigma_ref above.

**Both references and gradients accept a single float (applied to all sites)**

Again, I would not allow or warn if a single reference value was being applied to >1 nucleus.

<img width="735" height="26" alt="image" src="https://github.com/user-attachments/assets/7dcc09dc-54f1-4af3-9547-3eae836aa320" />

Peaks at +/- 3 Cq/16? 

**Why no 2pi for dipole?**

Again, an implementation note (and most of the following sections)







